### PR TITLE
fix: change listdatabase title type from string to []TextObject

### DIFF
--- a/notion/database_test.go
+++ b/notion/database_test.go
@@ -298,7 +298,25 @@ func getListDatabaseJSON() string {
 		  {
 			"object": "database",
 			"id": "668d797c-76fa-4934-9b05-ad288df2d136",
-			"title": "Grocery list",
+			"title": [
+                {
+                    "type": "text",
+                    "text": {
+                        "content": "Grocery list",
+                        "link": null
+                    },
+                    "annotations": {
+                        "bold": false,
+                        "italic": false,
+                        "strikethrough": false,
+                        "underline": false,
+                        "code": false,
+                        "color": "default"
+                    },
+                    "plain_text": "test",
+                    "href": null
+                }
+            ],
 			"properties": {
 			  "Name": {
 				"type": "title",
@@ -309,7 +327,25 @@ func getListDatabaseJSON() string {
 		  {
 			"object": "database",
 			"id": "74ba0cb2-732c-4d2f-954a-fcaa0d93a898",
-			"title": "Pantry",
+			"title": [
+                {
+                    "type": "text",
+                    "text": {
+                        "content": "Pantry",
+                        "link": null
+                    },
+                    "annotations": {
+                        "bold": false,
+                        "italic": false,
+                        "strikethrough": false,
+                        "underline": false,
+                        "code": false,
+                        "color": "default"
+                    },
+                    "plain_text": "test",
+                    "href": null
+                }
+            ],
 			"properties": {
 			  "Name": {
 				"type": "title",

--- a/notion/databases.go
+++ b/notion/databases.go
@@ -265,7 +265,7 @@ type ListDatabase struct {
 	ID             string                 `json:"id" mapstructure:"id"`
 	CreatedTime    string                 `json:"created_time" mapstructure:"created_time"`
 	LastEditedTime string                 `json:"last_edited_time" mapstructure:"last_edited_time"`
-	Title          string                 `json:"title" mapstructure:"title"`
+	Title          []TextObject           `json:"title" mapstructure:"title"`
 	Properties     map[string]interface{} `json:"properties" mapstructure:"properties"`
 }
 


### PR DESCRIPTION
## WHY
List database return []TextObject and not string. The notion documentation is wrong. This is the json i got from my curl.
```json
{
    "object": "list",
    "results": [
        {
            "object": "database",
            "id": "00000000-0000-0000-0000-000000000000",
            "created_time": "2021-05-26T11:07:57.029Z",
            "last_edited_time": "2021-05-26T11:08:00.000Z",
            "title": [
                {
                    "type": "text",
                    "text": {
                        "content": "test",
                        "link": null
                    },
                    "annotations": {
                        "bold": false,
                        "italic": false,
                        "strikethrough": false,
                        "underline": false,
                        "code": false,
                        "color": "default"
                    },
                    "plain_text": "test",
                    "href": null
                }
            ],
            "properties": {
                "Tags": {
                    "id": "ZVRw",
                    "type": "multi_select",
                    "multi_select": {
                        "options": []
                    }
                },
                "Name": {
                    "id": "title",
                    "type": "title",
                    "title": {}
                }
            }
        }
    ],
    "next_cursor": null,
    "has_more": false
}
```
<!-- (Write the motivation why you submit this pull request) -->
