### PR TITLE
Add go mod tidy for Renovate config

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,5 @@ go 1.16
 
 require (
 	github.com/google/go-cmp v0.5.5
-	github.com/mitchellh/mapstructure v1.4.1 // indirect
+	github.com/mitchellh/mapstructure v1.4.1
 )

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
     "extends": [
         "config:base"
-    ]
+    ],
+    "postUpdateOptions": ["gomodTidy"]
 }


### PR DESCRIPTION
## WHY

From 1.16, it need to run the `go mod tidy` to actually add packages.
